### PR TITLE
Add ja

### DIFF
--- a/locale/ja/foundry.cfg
+++ b/locale/ja/foundry.cfg
@@ -3,48 +3,48 @@ foundry=__ITEM__foundry__
 electric-foundry=__ITEM__electric-foundry__
 
 [entity-description]
-foundry=Melts and casts metals, can also heat up other things.
-electric-foundry=Melts and casts metals, can also heat up other things.
+foundry=金属を融解したのち鋳造します。他の物を高温に加熱するためにも使用できます。
+electric-foundry=金属を融解したのち鋳造します。他の物を高温に加熱するためにも使用できます。
 
 [item-name]
-foundry=Foundry
-electric-foundry=Electric foundry
-coke=Coke
+foundry=鋳造所
+electric-foundry=電気鋳造所
+coke=コークス
 
 [item-description]
-foundry=Melts and casts metals, can also heat up other things.
-electric-foundry=Melts and casts metals, can also heat up other things.
-coke=A pure fuel and source of carbon.
+foundry=金属を融解したのち鋳造します。他の物を高温に加熱するためにも使用できます。
+electric-foundry=金属を融解したのち鋳造します。他の物を高温に加熱するためにも使用できます。
+coke=純粋な燃料であり、炭素の供給源
 
 [recipe-name]
-solid-fuel-from-coal=Solid fuel from coal
-with-refractory=__1__ with refractory
+solid-fuel-from-coal=固形燃料 (石炭)
+with-refractory=__1__ (耐熱)
 
 [recipe-description]
-solid-fuel-from-coal=Make solid fuel from coal, a wasteful process.
+solid-fuel-from-coal=無駄の多いプロセスで石炭から固形燃料を作成します。
 
 [technology-name]
 foundry=__ITEM__foundry__
 electric-foundry=__ITEM__electric-foundry__
-advanced-founding=Advanced founding
-advanced-founding-space=Advanced founding of offworld materials
+advanced-founding=高度な鋳造
+advanced-founding-space=他の星の素材を使用した高度な鋳造
 
 [technology-description]
-foundry=Use heat for founding, coking, etc.
-advanced-founding=Alternate, efficient recipes for founding
+foundry=熱を用いて鋳造やコークス作成を行います。
+advanced-founding=高度で効率的な鋳造レシピ
 
 [mod-setting-name]
-bzfoundry-recipe-bypass=Bypass recipes
-bzfoundry-smelt=Foundry can smelt
-bzfoundry-plates=Add refractory recipes (experimental)
-bzfoundry-hydrocarbon=Hydrocarbon for founding
-bzfoundry-other-machines=Other machines that can do founding
-bzfoundry-minimal=Minimal mode (remove buildings)
+bzfoundry-recipe-bypass=変更しないレシピ
+bzfoundry-smelt=鋳造所で製錬可能
+bzfoundry-plates=耐熱レシピを追加 (実験的)
+bzfoundry-hydrocarbon=鋳造に使用する炭化水素類
+bzfoundry-other-machines=鋳造所以外に鋳造を行える設備
+bzfoundry-minimal=ミニマルモード (建造物を取り除く)
 
 [mod-setting-description]
-bzfoundry-recipe-bypass=Skip modifying these recipes (comma-separated list).
-bzfoundry-smelt=If true, the foundry building can also handle raw ore smelting.
-bzfoundry-hydrocarbon=Which hydrocarbon to use for founding. The foundry building is also used for coking.\nIf [color=cyan]coke[/color], a coke item and recipe is added, if needed.\nIf [color=cyan]solid fuel[/color], an early but inefficient recipe is added.\nIf [color=cyan]coal[/color], that is used.\nIf [color=cyan]none[/color], no hydrocarbon is used in founding (not recommended).
-bzfoundry-other-machines=List of other "assembling-machine" entities that can do "founding" recipes. Eg. Krastorio2's "kr-advanced-furnace", or AAII's "industrial-furnace" (comma-separated list).
-bzfoundry-plates=[color=orange]EXPERIMENTAL[/color] Ingredients, products, or anything might change.\nUsing one or more refractories, foundries can increase output of plates.\nBe warned, these are complex recipes.
-bzfoundry-minimal=[color=yellow]Use with caution![/color]\nIntended as a workaround for Factorio's required mod dependency system. Disables foundry buildings and recipe changes that rely on them. Allows you to play without Foundry with Aluminum, while still letting Foundry be a required dependency with default mod settings.
+bzfoundry-recipe-bypass=指定したレシピの改変を行わない。(コンマ区切り)
+bzfoundry-smelt=チェックすると、鋳造所で鉱石の製錬も行える。
+bzfoundry-hydrocarbon=鋳造に使用する炭化水素類。コークス化にも使用。\n[color=cyan]coke[/color]ならコークスとレシピが追加。\n[color=cyan]solid fuel[/color]なら初期から使えるが非効率な固形燃料レシピを追加。\n[color=cyan]coal[/color]なら石炭を使用。\n[color=cyan]none[/color]なら鋳造に炭化水素類を使用しない (非推奨)。
+bzfoundry-other-machines=鋳造所以外に "founding" レシピを実行できる "assembling-machine" エンティティの一覧。例: K2の "kr-advanced-furnace" や AAII の "industrial-furnace" (コンマ区切り)
+bzfoundry-plates=[color=orange]実験的[/color] 材料、生産物などあらゆる点が変更される可能性があります。\n一つ以上の耐熱素材を使うことで鋳造所における板材の生産量を向上することが出来ます。\n警告: 煩雑なレシピです。
+bzfoundry-minimal=[color=yellow]注意して使用のこと![/color]\nFactorioのMOD依存関係システムの問題回避を意図した設定。鋳造所とそれに依存したレシピを無効化します。デフォルトのMOD設定でFoundry MODを依存関係に残したまま、Aluminium MODをFoundry MODを使わずにプレイすることが可能になります。

--- a/locale/ja/foundry.cfg
+++ b/locale/ja/foundry.cfg
@@ -1,0 +1,50 @@
+[entity-name]
+foundry=__ITEM__foundry__
+electric-foundry=__ITEM__electric-foundry__
+
+[entity-description]
+foundry=Melts and casts metals, can also heat up other things.
+electric-foundry=Melts and casts metals, can also heat up other things.
+
+[item-name]
+foundry=Foundry
+electric-foundry=Electric foundry
+coke=Coke
+
+[item-description]
+foundry=Melts and casts metals, can also heat up other things.
+electric-foundry=Melts and casts metals, can also heat up other things.
+coke=A pure fuel and source of carbon.
+
+[recipe-name]
+solid-fuel-from-coal=Solid fuel from coal
+with-refractory=__1__ with refractory
+
+[recipe-description]
+solid-fuel-from-coal=Make solid fuel from coal, a wasteful process.
+
+[technology-name]
+foundry=__ITEM__foundry__
+electric-foundry=__ITEM__electric-foundry__
+advanced-founding=Advanced founding
+advanced-founding-space=Advanced founding of offworld materials
+
+[technology-description]
+foundry=Use heat for founding, coking, etc.
+advanced-founding=Alternate, efficient recipes for founding
+
+[mod-setting-name]
+bzfoundry-recipe-bypass=Bypass recipes
+bzfoundry-smelt=Foundry can smelt
+bzfoundry-plates=Add refractory recipes (experimental)
+bzfoundry-hydrocarbon=Hydrocarbon for founding
+bzfoundry-other-machines=Other machines that can do founding
+bzfoundry-minimal=Minimal mode (remove buildings)
+
+[mod-setting-description]
+bzfoundry-recipe-bypass=Skip modifying these recipes (comma-separated list).
+bzfoundry-smelt=If true, the foundry building can also handle raw ore smelting.
+bzfoundry-hydrocarbon=Which hydrocarbon to use for founding. The foundry building is also used for coking.\nIf [color=cyan]coke[/color], a coke item and recipe is added, if needed.\nIf [color=cyan]solid fuel[/color], an early but inefficient recipe is added.\nIf [color=cyan]coal[/color], that is used.\nIf [color=cyan]none[/color], no hydrocarbon is used in founding (not recommended).
+bzfoundry-other-machines=List of other "assembling-machine" entities that can do "founding" recipes. Eg. Krastorio2's "kr-advanced-furnace", or AAII's "industrial-furnace" (comma-separated list).
+bzfoundry-plates=[color=orange]EXPERIMENTAL[/color] Ingredients, products, or anything might change.\nUsing one or more refractories, foundries can increase output of plates.\nBe warned, these are complex recipes.
+bzfoundry-minimal=[color=yellow]Use with caution![/color]\nIntended as a workaround for Factorio's required mod dependency system. Disables foundry buildings and recipe changes that rely on them. Allows you to play without Foundry with Aluminum, while still letting Foundry be a required dependency with default mod settings.


### PR DESCRIPTION
This PR adds ja locale to the Foundry MOD.

Because options of `bzfoundry-hydrocarbon` (`coke`, `solid fuel`, `coal` and `none`) seem not translatable, I left them untranslated in its description (`mod-setting-description.bzfoundry-hydrocarbon`).